### PR TITLE
Update Forked Nearley NPM Scope and Version

### DIFF
--- a/mongodb-modifications.md
+++ b/mongodb-modifications.md
@@ -1,0 +1,12 @@
+# MongoDB Modifications
+
+This file details the modifications made to nearley as compared to the upstream.
+
+## Differences
+
+tbd
+
+## Version History
+
+- v1.0.0: Corresponds to nearley v2.16.0
+

--- a/mongodb-modifications.md
+++ b/mongodb-modifications.md
@@ -8,5 +8,5 @@ tbd
 
 ## Version History
 
-- v1.0.0: Corresponds to nearley v2.16.0
+- v0.1.0: Corresponds to nearley v2.16.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-forks/nearley",
-  "version": "2.16.0",
+  "version": "1.0.0",
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-forks/nearley",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nearley",
+  "name": "@mongodb-forks/nearley",
   "version": "2.16.0",
   "description": "Simple, fast, powerful parser toolkit for JavaScript.",
   "main": "lib/nearley.js",
@@ -42,7 +42,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hardmath123/nearley.git"
+    "url": "https://github.com/mongodb-forks/nearley.git"
   },
   "devDependencies": {
     "@types/moo": "^0.3.0",


### PR DESCRIPTION
Does what it says on the tin.

Decided to use different version-numbers. This lets us properly follow SemVer without fear of colliding with nearley's numbering.

Once this is merged I'll copy our modifications that are currently vendored and then publish to npm.
