### PR TITLE
TIG-1906 Allow passing in external lexer file

### DIFF
--- a/bin/nearleyc.js
+++ b/bin/nearleyc.js
@@ -4,7 +4,9 @@ var fs = require('fs');
 var nearley = require('../lib/nearley.js');
 var opts = require('commander');
 var Compile = require('../lib/compile.js');
-var StreamWrapper = require('../lib/stream.js');
+var StreamWrapper = require('../lib/stream.js').StreamWrapper;
+var LexerStreamWrapper = require('../lib/stream.js').LexerStreamWrapper;
+
 
 var version = require('../package.json').version;
 
@@ -29,7 +31,7 @@ var lint = require('../lib/lint.js');
 
 function parseLexer(callback) {
     lexer
-        .pipe(new StreamWrapper(parser, true))
+        .pipe(new LexerStreamWrapper(parser))
         .on('finish', function() {
             callback();
         });
@@ -37,7 +39,7 @@ function parseLexer(callback) {
 
 function parseGrammar() {
     input
-        .pipe(new StreamWrapper(parser, false))
+        .pipe(new StreamWrapper(parser))
         .on('finish', function() {
             parser.feed('\n');
             var c = Compile(

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -3,20 +3,31 @@
 var Writable = require('stream').Writable;
 var util = require('util');
 
-function StreamWrapper(parser, isLexer) {
+function StreamWrapper(parser) {
     Writable.call(this);
     this._parser = parser;
-    this._isLexer = isLexer;
 }
 
 util.inherits(StreamWrapper, Writable);
 
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
-    if (this._isLexer) {
-        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer\n';
-    }
     this._parser.feed(chunk.toString());
     callback();
 };
 
-module.exports = StreamWrapper;
+function LexerStreamWrapper(parser) {
+    StreamWrapper.call(this, parser);
+}
+
+util.inherits(LexerStreamWrapper, StreamWrapper);
+
+LexerStreamWrapper.prototype._write = function write(chunk, encoding, callback) {
+    // To support having lexer files be valid javascript files, the special nearley syntax is
+    // hardcoded into to the chunk. Ideally we would write a more native solution for this.
+    chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer\n';
+
+    // Now we call _write() with the amended 'chunk'.
+    StreamWrapper.prototype._write.call(this, chunk, encoding, callback);
+}
+
+module.exports = {StreamWrapper, LexerStreamWrapper};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -13,7 +13,7 @@ util.inherits(StreamWrapper, Writable);
 
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
     if (this._isLexer) {
-        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer ';
+        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer\n';
     }
     this._parser.feed(chunk.toString());
     callback();

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -3,14 +3,18 @@
 var Writable = require('stream').Writable;
 var util = require('util');
 
-function StreamWrapper(parser) {
+function StreamWrapper(parser, isLexer) {
     Writable.call(this);
     this._parser = parser;
+    this._isLexer = isLexer;
 }
 
 util.inherits(StreamWrapper, Writable);
 
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
+    if (this._isLexer) {
+        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer';
+    }
     this._parser.feed(chunk.toString());
     callback();
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -13,7 +13,7 @@ util.inherits(StreamWrapper, Writable);
 
 StreamWrapper.prototype._write = function write(chunk, encoding, callback) {
     if (this._isLexer) {
-        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer';
+        chunk = '@{% ' + chunk.toString() + ' %} @lexer lexer ';
     }
     this._parser.feed(chunk.toString());
     callback();

--- a/test/grammars/external-lexer/grammar.ne
+++ b/test/grammars/external-lexer/grammar.ne
@@ -1,0 +1,5 @@
+# Use %token to match any token of that type instead of "token":
+multiplication -> %number %ws %times %ws %number {% ([first, , , , second]) => first * second %}
+
+# Literal strings now match tokens with that text:
+trig -> "sin" %number

--- a/test/grammars/external-lexer/grammar2.ne
+++ b/test/grammars/external-lexer/grammar2.ne
@@ -1,0 +1,3 @@
+@include "./included-grammar.ne"
+
+mult -> nums %ws %times %ws nums

--- a/test/grammars/external-lexer/included-grammar.ne
+++ b/test/grammars/external-lexer/included-grammar.ne
@@ -1,0 +1,1 @@
+nums -> %number %ws %number

--- a/test/grammars/external-lexer/lexer.js
+++ b/test/grammars/external-lexer/lexer.js
@@ -1,0 +1,8 @@
+const moo = require("moo");
+
+const lexer = moo.compile({
+    ws:     /[ \t]+/,
+    number: /[0-9]+/,
+    word: /[a-z]+/,
+    times:  /\*|x/
+});

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -108,6 +108,15 @@ describe("bin/nearleyc", function() {
         expect(() => parse(grammar, "15 * 10")).toNotThrow();
         expect(() => parse(grammar, "word15 * 10")).toThrow();
     });
+
+    it("builds correctly with externally defined lexer and included file", function () {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/external-lexer/grammar2.ne", '.js', ['--lexer grammars/external-lexer/lexer.js']);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("");
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        expect(() => parse(grammar, "15 10 * 2 11")).toNotThrow();
+        expect(() => parse(grammar, "12 10 * word 11")).toThrow();
+    });
 })
 
 describe('nearleyc: example grammars', function() {

--- a/test/nearleyc.test.js
+++ b/test/nearleyc.test.js
@@ -100,7 +100,14 @@ describe("bin/nearleyc", function() {
         expect(stderr).toBe("");
     });
 
-
+    it("builds correctly with externally defined lexer", function () {
+        const {outPath, stdout, stderr} = externalNearleyc("grammars/external-lexer/grammar.ne", '.js', ['--lexer grammars/external-lexer/lexer.js']);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("");
+        const grammar = nearley.Grammar.fromCompiled(require(`./${outPath}.js`));
+        expect(() => parse(grammar, "15 * 10")).toNotThrow();
+        expect(() => parse(grammar, "word15 * 10")).toThrow();
+    });
 })
 
 describe('nearleyc: example grammars', function() {


### PR DESCRIPTION
This lets us separate `.ne` grammar files and lexers, so that we can compile one grammar file with different lexer objects. 

`nearleyc.js` compiles grammars by first creating a bootstrapped `parserGrammar` object, then creating a `fs.readStream()` object with the `.ne` file and feeding that as a string to the `parserGrammar`. 

This change adds a `--lexer` cmd line option, and if one is passed, does the same as the above but for this file. It then feeds the `.ne` file as it did previously. So essentially it's a slightly convoluted way of loading in two files as strings and concatenating them before feeding them to the parser. 